### PR TITLE
Add support for timestamps with microseconds

### DIFF
--- a/logview.el
+++ b/logview.el
@@ -82,6 +82,7 @@ This alist value is used as the fallback for customizable
   (let ((HH:mm:ss          "[012][0-9]:[0-5][0-9]:[0-5][0-9]")
         (h:mm:ss           "[ 01]?[0-9]:[0-5][0-9]:[0-5][0-9]")
         (.SSS              "[.,][0-9]\\{3\\}")
+        (.UUUUUU           "[.,][0-9]\\{6\\}")
         (a                 " [AP]M")
         (yyyy-MM-dd        "[0-9]\\{4\\}-[01][0-9]-[0-3][0-9]")
         (MMM               (regexp-opt '("Jan" "Feb" "Mar" "Apr" "May" "Jun" "Jul" "Aug" "Sep" "Oct" "Nov" "Dec")))
@@ -90,6 +91,9 @@ This alist value is used as the fallback for customizable
     (list (list "ISO 8601 datetime + millis"
                 (cons 'regexp  (concat yyyy-MM-dd " " HH:mm:ss .SSS))
                 (list 'aliases "yyyy-MM-dd HH:mm:ss.SSS"))
+          (list "ISO 8601 datetime + micros"
+                (cons 'regexp  (concat yyyy-MM-dd " " HH:mm:ss .UUUUUU))
+                (list 'aliases "yyyy-MM-dd HH:mm:ss.UUUUUU"))
           (list "ISO 8601 datetime"
                 (cons 'regexp  (concat yyyy-MM-dd " " HH:mm:ss))
                 (list 'aliases "yyyy-MM-dd HH:mm:ss"))


### PR DESCRIPTION
Overview
------------

By default, Boost Log configuration uses timestamps with microseconds. Whilst this is not particularly useful - given most users' clock resolution - it happens to be quite hard to change[1],[2]. So, to make life easier for Boost Log users I've added support for timestamps with microseconds.

Notes
--------

This PR is the result of the discussion in #3. I could not get it to work via customize, and I also think it will be a worthwhile addition to LogView for all users of Boost Log stuck with microseconds.

[1] http://stackoverflow.com/questions/27870064/how-to-truncate-boost-log-format-expression
[2] http://stackoverflow.com/questions/5947018/how-to-customize-timestamp-format-of-boost-log