### PR TITLE
Heed value of logview-cache-filename

### DIFF
--- a/logview.el
+++ b/logview.el
@@ -2521,7 +2521,7 @@ returns non-nil."
     ;; not only in memory, but also on disk.  We use `extmap' to create and read the cache
     ;; file.  If `datetime' reports a different locale database version, cache is
     ;; discarded.
-    (let* ((cache-filename          (locate-user-emacs-file "logview-cache.extmap"))
+    (let* ((cache-filename          logview-cache-filename)
            (cache-file              (ignore-errors (extmap-init cache-filename)))
            (locale-database-version (if (fboundp #'datetime-locale-database-version) (with-no-warnings (datetime-locale-database-version)) 0)))
       (when cache-file


### PR DESCRIPTION
This fixes a previous change[1] which resulted in the value of the user option `logview-cache-filename` never being used.

[1]: Add view quick access indices to further simplify switching between views.
41c759a20cb26418c97807e09d034381070d0311 2020-01-19 23:39:23 +0100

Re: PR #27.