### PR TITLE
Fix logview-go-to-difference-base-entry for submodes with no threads

### DIFF
--- a/logview.el
+++ b/logview.el
@@ -1935,7 +1935,8 @@ it stays in effect for other threads."
   (logview--assert 'timestamp)
   (logview--std-temporarily-widening
     (logview--locate-current-entry entry start
-      (let* ((thread          (logview--entry-group entry start logview--thread-group))
+      (let* ((thread          (when (memq 'thread logview--submode-features)
+                                (logview--entry-group entry start logview--thread-group)))
              (difference-base (or (when logview--timestamp-difference-per-thread-bases
                                     (gethash thread logview--timestamp-difference-per-thread-bases))
                                   logview--timestamp-difference-base)))

--- a/test/logview.el
+++ b/test/logview.el
@@ -104,6 +104,14 @@
     (logview--locate-current-entry entry start
       (should (and entry (equal start 1))))))
 
+(ert-deftest logview-test-go-to-difference-base-entry-no-thread ()
+  (logview--test-with-file "custom/1.log" ((logview-additional-submodes
+                                            '(("custom" (format . "TIMESTAMP LEVEL [NAME] ") (levels . "SLF4J")))))
+     (logview-difference-to-current-entry)
+     (logview-go-to-difference-base-entry)))
+
+
+
 ;; RFC 5424 levels.
 ;;
 ;; The mock log file should have a list of log messages in the default


### PR DESCRIPTION
Previously, `logview-go-to-difference-base-entry` would signal
"Wrong type argument: number-or-marker-p, nil" when used in a buffer with a
threadless submode. This commit fixes this by avoiding the offending call to
`logview--entry-group` when threads are not used. It also adds a regression test
for this case.