### PR TITLE
WIP: Submodes for JSON logs

### DIFF
--- a/logview.el
+++ b/logview.el
@@ -3068,6 +3068,7 @@ returns non-nil."
           logview--process-buffer-changes t
           logview--entry-regexp           entry-regexp
           logview--submode-features       features
+	  logview--json-display-groups    features
           logview--submode-level-data     nil)
    (logview--update-mode-name)
    (when (memq 'level features)

--- a/test/json/levels.log
+++ b/test/json/levels.log
@@ -1,0 +1,5 @@
+{"timestamp":"2022-12-14T04:35:54.115","level":"ERROR","thread":"main-1","logger":"main","message":"Error message"}
+{"timestamp":"2022-12-14T04:36:54.115","level":"WARN","thread":"main-1","logger":"main","message":"Warning message"}
+{"timestamp":"2022-12-14T04:36:55.115","level":"INFO","thread":"main-1","logger":"main","message":"Info message"}
+{"timestamp":"2022-12-14T04:36:55.116","level":"DEBUG","thread":"main-1","logger":"main","message":"Debug message"}
+{"timestamp":"2022-12-14T04:37:57.115","level":"TRACE","thread":"main-1","logger":"main","message":"Trace message"}

--- a/test/logview.el
+++ b/test/logview.el
@@ -498,3 +498,18 @@
       (should (memq 'logview-name              faces))
       (should (memq 'logview-information-entry faces))
       (should (memq 'bold                      faces)))))
+
+;; JSON submode
+
+(ert-deftest logview-test-json-match-all-levels ()
+  (logview--test-with-file "json/levels.log"
+    (should (equal logview--submode-name "JSON"))
+    (should (equal (logview--locate-current-entry entry nil (logview--entry-level entry)) 0))
+    (logview-next-entry)
+    (should (equal (logview--locate-current-entry entry nil (logview--entry-level entry)) 1))
+    (logview-next-entry)
+    (should (equal (logview--locate-current-entry entry nil (logview--entry-level entry)) 2))
+    (logview-next-entry)
+    (should (equal (logview--locate-current-entry entry nil (logview--entry-level entry)) 3))
+    (logview-next-entry)
+    (should (equal (logview--locate-current-entry entry nil (logview--entry-level entry)) 4))))


### PR DESCRIPTION
I've been working with some projects that emit logs in JSON and found myself wishing that I could work with those logs efficiently in Emacs, so with a little free time on my hands I decided to dive into `logview-mode` to see what I could make it do, and added a JSON submode.

The easiest way to check this out is to open `test/json/levels.log`.  On the bottom of the cheat sheet there are several new commands with the prefix `j` .

### Things it does:
- Recognizes JSON-lines content (one JSON object per line).
- Parses JSON log entries.
- Finds the timestamp, level, thread, name and message in the object (where they are located is configurable).
- Implements filtering based on those values.
- Fontifies based on those values.
- During fontification puts values from the JSON in the `line-prefix` text property for each entry, and provides commands to toggle display of those values on and off.
- Implements timestamp diffing.
- Can show you pretty-printed JSON in a separate buffer.
- Can show you the Lisp object parsed from the JSON pretty-printed in a separate buffer.

### Things that aren't done:
- Recognize JSON objects spanning multiple lines.
- Deal with intermixed plain text and JSON.
- Handle entries with missing values.
- Let you select text from the values you are displaying in the line prefix.
- Update the README to explain how to add new JSON submodes.

### Things I'm thinking about making it do:
- Save the selection of values to show in the line-prefix with the view.
- Since you can't select line-prefix text, add some commands that copy values to the kill ring.  Those commands could work in plain text logging submodes too.
- Define custom paths to extract values from the JSON that you can use in filtering or display in the line prefix.
- Add a configurable hook or fixup function to run after the JSON is parsed to modify the object (for example I'm working with a library that logs strings containing JSON inside the JSON, so a fixup function could parse those).
- Apply json-mode fontification to each entry.